### PR TITLE
feat: Implement visited location tracking and simplified movement

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -39,9 +39,31 @@ const refreshStats = () => {
 // Build synonym lookup
 const buildSynonymMap = () => {
     SYNON_MAP = {};
+    // Existing loop to populate from DATA.synonyms
     for (const [canon, list] of Object.entries(DATA.synonyms)) {
         (Array.isArray(list) ? list : [list]).forEach(s => SYNON_MAP[s] = canon);
-        SYNON_MAP[canon] = canon;
+        SYNON_MAP[canon] = canon; // Ensure canonical form maps to itself
+    }
+
+    // Add single-letter movement synonyms directly
+    SYNON_MAP['n'] = 'norr';
+    SYNON_MAP['s'] = 'söder';
+    SYNON_MAP['e'] = 'öster';
+    SYNON_MAP['w'] = 'väster';
+    SYNON_MAP['ö'] = 'öster'; // Swedish specific 'Ö' for East
+    SYNON_MAP['v'] = 'väster'; // Swedish specific 'V' for West
+    SYNON_MAP['u'] = 'upp';
+    SYNON_MAP['d'] = 'ned';
+    
+    // Also ensure that the canonical direction words still map to themselves
+    // if not already covered by DATA.synonyms processing (e.g. if 'norr' isn't a key in DATA.synonyms)
+    // Though the original loop's `SYNON_MAP[canon] = canon;` should handle this if directions are canonical keys.
+    // Adding them explicitly here for robustness is fine.
+    const directions = ['norr', 'söder', 'öster', 'väster', 'upp', 'ned'];
+    for (const dir of directions) {
+        if (!SYNON_MAP[dir]) {
+            SYNON_MAP[dir] = dir;
+        }
     }
 };
 
@@ -64,35 +86,64 @@ const matchesConditions = cs => !cs || cs.every(cond => {
 // Cleans user input: lowercases, strips punctuation, trims
 const normalize = s => (s || '').toLowerCase().replace(/[^\wåäö\s]/gi, '').trim();
 
-const doLook = (raw = '') => {
-    const norm = normalize(raw);
-    const words = norm.split(/\s+/);
-    const explicitDescribe = /^(beskriv|granska|utforska)\b/.test(norm);
+const doLook = (rawInput = '') => {
+    const normalizedInput = normalize(rawInput);
+    const inputWords = normalizedInput.split(/\s+/);
+    // Determine the canonical verb. If 'beskriv' was passed directly by process(), it's 'describe'.
+    // Otherwise, map the first word. Fallback to the word itself if not in SYNON_MAP.
+    const commandVerb = (rawInput === 'beskriv') ? 'describe' : (SYNON_MAP[inputWords[0]] || inputWords[0]);
 
-    // --- Först: titta på ett föremål? ---
-    if (SYNON_MAP[words[0]] === 'look' && words.length> 1) {
-        const target = SYNON_MAP[words.slice(1).join(' ')];
-        const place = DATA.places[state.loc];
-        if (target && (place.items.includes(target) || state.inventory.includes(target))) {
-            print(DATA.items[target].desc);
+    // isExplicitlyDescribingLocation is true if the 'describe' verb is effectively used.
+    const isExplicitlyDescribingLocation = commandVerb === 'describe';
+
+    // --- Part 1: Try to look at a specific item ---
+    // This section executes if the command is 'look' (not 'describe') and has a target.
+    if (!isExplicitlyDescribingLocation && commandVerb === 'look' && inputWords.length > 1) {
+        const targetName = inputWords.slice(1).join(' '); // Use all words after 'look' as potential item name
+        const targetItemId = SYNON_MAP[targetName]; // Resolve if targetName is a synonym for an item ID
+        const currentPlace = DATA.places[state.loc];
+
+        // Check if the resolved targetItemId is a valid item and present in the location or inventory
+        if (targetItemId && DATA.items[targetItemId] && (currentPlace.items.includes(targetItemId) || state.inventory.includes(targetItemId))) {
+            print(DATA.items[targetItemId].desc);
+            // Standard IF behavior: after describing a specific item, the action is complete.
             return true;
         }
+        // If "look <something>" was typed, but <something> isn't a recognized/present item,
+        // we fall through to describing the location itself. This matches original behavior.
     }
 
-    // --- Fallback: beskriv platsen ---
+    // --- Part 2: Describe the location ---
     const place = DATA.places[state.loc];
-    const firstVisit = !state.visited.has(state.loc);
+    const isFirstActualVisit = !state.visited.has(state.loc); // True only if state.loc is not in state.visited set
 
-    if ((firstVisit || explicitDescribe) && (place.longDesc || place.ascii)) {
-        if (place.ascii)
-            print(place.ascii);
-        if (place.longDesc)
-            print(place.longDesc);
-        state.visited.add(state.loc);
+    let shownSpecifics = false; // Helper flag to track if ASCII or longDesc was shown
+
+    if (isExplicitlyDescribingLocation) {
+        // Always show long description and/or ASCII art for "describe" commands
+        if (place.ascii) { print(place.ascii); shownSpecifics = true; }
+        if (place.longDesc) { print(place.longDesc); shownSpecifics = true; }
+        // If "describe" was used but the place has no ascii or longDesc, show the short description.
+        if (!shownSpecifics) { print(place.desc); }
+    } else if (isFirstActualVisit) {
+        // For the first visit to a location (and not an explicit "describe" command)
+        if (place.ascii) { print(place.ascii); shownSpecifics = true; }
+        if (place.longDesc) { print(place.longDesc); shownSpecifics = true; }
+        // If it's a first visit and the place has no ascii or longDesc, show the short description.
+        if (!shownSpecifics) { print(place.desc); }
     } else {
+        // For subsequent visits (not a first visit and not an explicit "describe")
         print(place.desc);
     }
 
+    // Add location to state.visited if this was its first actual visit.
+    // This ensures it's marked visited regardless of whether long/ascii or short desc was shown.
+    if (isFirstActualVisit) {
+        state.visited.add(state.loc);
+    }
+
+    // --- Part 3: List items in the location ---
+    // This runs unless the function returned early after describing a specific item.
     if (place.items.length) {
         print('Du ser: ' + place.items.map(i => i.charAt(0).toUpperCase() + i.slice(1)).join(', '));
     }
@@ -138,20 +189,45 @@ const doTake = raw => {
     return true;
 };
 
-const doMove = cmd => {
-    const dir = ['norr', 'söder', 'öster', 'väster', 'upp', 'ned'].find(d => cmd.includes(d));
-    if (!dir) {
+const doMove = cmd => { // cmd is the raw normalized input, e.g., "gå norr", "norr", "n"
+    const words = cmd.split(/\s+/);
+    let foundDir = null;
+
+    // Iterate over words to find a recognized direction
+    for (const word of words) {
+        // Check if the word itself is a direction (e.g. "norr") or a synonym ("n")
+        // SYNON_MAP should provide the canonical direction name (e.g. SYNON_MAP['n'] -> 'norr')
+        const canonicalWord = SYNON_MAP[word]; 
+        if (['norr', 'söder', 'öster', 'väster', 'upp', 'ned'].includes(canonicalWord)) {
+            foundDir = canonicalWord;
+            break;
+        }
+    }
+    
+    // Fallback for cases like "gå norrut" where "norr" is part of the word,
+    // or if the synonym mapping isn't perfect for all command structures.
+    // This ensures existing behavior like "gå norr" still works if "norr" isn't a standalone word in `words` that maps directly.
+    if (!foundDir) {
+        // This will catch 'norr' in 'gå norr', assuming 'gå' isn't a mapped direction.
+        // It also covers cases where SYNON_MAP might not yet be populated with single letters,
+        // though the next plan step is to update SYNON_MAP.
+        foundDir = ['norr', 'söder', 'öster', 'väster', 'upp', 'ned'].find(d => cmd.includes(d));
+    }
+
+    if (!foundDir) {
         print('Vart vill du gå?');
         return;
     }
+
     const place = DATA.places[state.loc];
-    const dest = place.exits[dir];
+    const dest = place.exits[foundDir]; // Use the resolved direction
+
     if (!dest) {
-        print(`Du kan inte gå ${dir}.`);
+        print(`Du kan inte gå ${foundDir}.`);
         return;
     }
     state.loc = dest;
-    doLook();
+    doLook(); // doLook will handle visited status correctly
     refreshStats();
 };
 
@@ -191,9 +267,28 @@ const handleActions = raw => {
     return false;
 };
 
-const findVerb = words =>
-    words.map(w => SYNON_MAP[w])
-    .find(v => ['look', 'survey', 'take', 'move', 'inventory', 'light', 'help', 'quit', 'describe'].includes(v));
+const findVerb = words => {
+    // Map all words to their canonical forms via SYNON_MAP.
+    // SYNON_MAP should already be populated with single letters mapping to directions (e.g., SYNON_MAP['n'] = 'norr')
+    // and action words to canonical verbs (e.g., SYNON_MAP['gå'] = 'move').
+    const mappedWords = words.map(w => SYNON_MAP[w]);
+
+    // First, try to find a primary verb (look, take, move, etc.)
+    let verb = mappedWords.find(v => ['look', 'survey', 'take', 'move', 'inventory', 'light', 'help', 'quit', 'describe'].includes(v));
+    if (verb) {
+        return verb;
+    }
+
+    // If no direct verb was found, check if any of the (mapped) words is a known direction.
+    // If so, interpret this as a 'move' command.
+    // This allows inputs like "n" (mapped to "norr") to be treated as "move".
+    const isDirection = mappedWords.some(mappedWord => ['norr', 'söder', 'öster', 'väster', 'upp', 'ned'].includes(mappedWord));
+    if (isDirection) {
+        return 'move';
+    }
+
+    return undefined; // No recognized verb or direction found
+};
 const process = input => {
 
     if (!input.trim())


### PR DESCRIPTION
This commit introduces two main features:

1. Visited Location Tracking:
   - The game now tracks visited locations.
   - On your first visit to a location, its ASCII art (if available) and long description (if available) are displayed. If neither is present, the short description is shown.
   - On subsequent visits, only the short description is displayed.
   - The `beskriv` (describe) command will always show the ASCII art and long description (or short description if the others are missing), regardless of visit status.
   - The `doLook()` function was significantly updated to handle these rules and correctly manage the `state.visited` set.

2. Simplified Movement Commands:
   - You can now use single letters for navigation (n, s, e, w, ö, v, u, d).
   - `doMove()` was updated to parse these and full direction names.
   - `buildSynonymMap()` was updated to include these single-letter synonyms.
   - `findVerb()` was updated to recognize that a direction input alone implies a "move" action.

These changes enhance your experience by providing more immersive location descriptions and more convenient navigation.