### PR TITLE
Fix: Update item names to new convention across codebase

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -2,27 +2,27 @@ const actions = {
   "*": [ // Generella handlingar
     {
       "pattern": "(tänd|starta|använd) lykta",
-      "conditions": ["has:rostig_lykta", "item:rostig_lykta:Släckt", "item_gt:rostig_lykta:fuel:0"],
+      "conditions": ["has:lykta", "item:lykta:Släckt", "item_gt:lykta:fuel:0"],
       "response": "Du tänder den rostiga lyktan. Ett varmt sken sprider sig och jagar bort de värsta skuggorna.",
-      "state_change": {"item":"rostig_lykta","state":"Tänd"}
+      "state_change": {"item":"lykta","state":"Tänd"}
     },
     {
       "pattern": "(tänd|starta|använd) lykta",
-      "conditions": ["has:rostig_lykta", "item:rostig_lykta:Släckt", "item_eq:rostig_lykta:fuel:0"],
+      "conditions": ["has:lykta", "item:lykta:Släckt", "item_eq:lykta:fuel:0"],
       "response": "Lyktan är tom på fotogen. Du behöver fylla på den.",
     },
     {
       "pattern": "(släck|stäng av) lykta",
-      "conditions": ["has:rostig_lykta", "item:rostig_lykta:Tänd"],
+      "conditions": ["has:lykta", "item:lykta:Tänd"],
       "response": "Du släcker lyktan. Mörkret tätnar omkring dig.",
-      "state_change": {"item":"rostig_lykta","state":"Släckt"}
+      "state_change": {"item":"lykta","state":"Släckt"}
     },
     {
       "pattern": "(fyll|fylla på) lykta med fotogen",
-      "conditions": ["has:rostig_lykta", "has:fotogen_flaska"],
+      "conditions": ["has:lykta", "has:fotogen"],
       "response": "Du fyller försiktigt på fotogen i lyktan från flaskan. Nu bör den lysa ett bra tag.",
-      "state_change": {"item":"rostig_lykta","key":"fuel", "value": 100}, // Sätter bränsle till max
-      "consume_item": "fotogen_flaska" // Förbrukar fotogenflaskan (eller minskar dess innehåll)
+      "state_change": {"item":"lykta","key":"fuel", "value": 100}, // Sätter bränsle till max
+      "consume_item": "fotogen" // Förbrukar fotogenflaskan (eller minskar dess innehåll)
     },
     {
       "pattern": "(läs|titta i|undersök) dagbok",
@@ -32,23 +32,23 @@ const actions = {
     },
     {
         "pattern": "(kombinera|sätt ihop|laga) stjärnlins",
-        "conditions": ["has:stjärnlins_bit1", "has:stjärnlins_bit2"],
+        "conditions": ["has:linsbit", "has:linsbitett"],
         "response": "Du fogar försiktigt ihop de två linsbitarna. De passar perfekt och bildar en komplett stjärnlins!",
-        "remove_items": ["stjärnlins_bit1", "stjärnlins_bit2"],
-        "add_item": "komplett_stjärnlins"
+        "remove_items": ["linsbit", "linsbitett"],
+        "add_item": "stjärnlins"
     },
     {
         "pattern": "(kombinera|sätt ihop) runstenar",
-        "conditions": ["has:runsten_del1", "has:runsten_del2", "has:runsten_del3"],
+        "conditions": ["has:runstenbit", "has:runstenbitett", "has:runstenbittva"],
         "response": "Du placerar de tre runstensbitarna bredvid varandra. De dras magiskt samman och bildar en enda sten med en lysande symbol!",
-        "remove_items": ["runsten_del1", "runsten_del2", "runsten_del3"],
-        "add_item": "samlad_runsten"
+        "remove_items": ["runstenbit", "runstenbitett", "runstenbittva"],
+        "add_item": "runsten"
     },
     {
       "pattern": "(drick|använd) stärkande svamp",
-      "conditions": ["has:stärkande_svamp"],
+      "conditions": ["has:styrkesvamp"],
       "response": "Du äter den stärkande svampen. En varm känsla sprider sig i kroppen och du känner dig starkare!",
-      "consume_item": "stärkande_svamp",
+      "consume_item": "styrkesvamp",
       "set_player_state": {"key": "styrka", "value": "förhöjd", "duration": 5} // Tillfällig effekt i X antal "turer" eller rumbyten
     }
     // Fler generella handlingar för att använda/kombinera föremål kan läggas till här.
@@ -63,17 +63,17 @@ const actions = {
     {
       "pattern": "(ta|plocka upp) lykta",
       "response": "Du tar den rostiga lyktan.",
-      "pickup_item": "rostig_lykta",
-      "remove_from_room": "rostig_lykta"
+      "pickup_item": "lykta",
+      "remove_from_room": "lykta"
     }
   ],
   "uråldriga_eken": [
     {
       "pattern": "(ta|plocka upp|dra loss) nyckel",
-      "conditions": ["room_has:uråldrig_nyckel"],
+      "conditions": ["room_has:nyckel"],
       "response": "Du drar loss en tung, uråldrig nyckel som satt fastkilad bland ekens rötter.",
-      "pickup_item": "uråldrig_nyckel",
-      "remove_from_room": "uråldrig_nyckel"
+      "pickup_item": "nyckel",
+      "remove_from_room": "nyckel"
     },
     {
         "pattern": "(klättra|gå) nedåt",
@@ -84,9 +84,9 @@ const actions = {
   "vattendragets_källa": [
     {
       "pattern": "(rena|använd kristall på) vatten",
-      "conditions": ["has:renande_kristall"],
+      "conditions": ["has:kristall"],
       "response": "Du doppar den renande kristallen i det grumliga vattnet. Långsamt klarnar vattnet och börjar skimra svagt. Du fyller en flaska med det nu heliga vattnet.",
-      "add_item": "heligt_vatten_flaska",
+      "add_item": "källvatten",
       "state_change": {"room_item":"vattendragets_källa", "property":"description_suffix", "value":" Vattnet är nu kristallklart och skimrande."} // Ändrar beskrivningen av rummet/källan
     },
     {
@@ -103,7 +103,7 @@ const actions = {
   "stenringen": [
     {
       "pattern": "(placera|använd) runstenar (på|vid) altare",
-      "conditions": ["has:samlad_runsten", "at_location:stenringen"], // `at_location` är en hypotetisk condition
+      "conditions": ["has:runsten", "at_location:stenringen"], // `at_location` är en hypotetisk condition
       "response": "Du placerar den samlade runstenen på det lilla stenaltaret. Symbolen på stenen börjar lysa starkare, och du hör ett dovt muller från öster, som om en passage har öppnats.",
       "state_change": {"world_event":"stenring_aktiverad", "value":true} // Kan låsa upp en ny väg eller ändra något i "murkna_grottan_ingång"
     }
@@ -111,14 +111,14 @@ const actions = {
   "murkna_grottan_första_rummet": [
     {
       "pattern": "(ta|plocka) mossa",
-      "conditions": ["room_has:glimmande_mossa_klump", "item:rostig_lykta:Släckt"], // Kanske man bara ser den om lyktan är släckt först?
+      "conditions": ["room_has:mossklump", "item:lykta:Släckt"], // Kanske man bara ser den om lyktan är släckt först?
       "response": "Du tar en klump av den svagt lysande mossan.",
-      "pickup_item": "glimmande_mossa_klump",
-      "remove_from_room": "glimmande_mossa_klump"
+      "pickup_item": "mossklump",
+      "remove_from_room": "mossklump"
     },
     {
       "pattern": "(tänd|använd) mossa",
-      "conditions": ["has:glimmande_mossa_klump"],
+      "conditions": ["has:mossklump"],
       "response": "Den glimmande mossan ger ifrån sig tillräckligt med ljus för att du ska kunna se dig omkring i det närmaste.",
       // Sätt en temporär ljus-flagga eller liknande.
     }
@@ -143,17 +143,17 @@ const actions = {
   "rotkällare": [
     {
         "pattern": "(öppna|lås upp) (trälåda|låda) med nyckel",
-        "conditions": ["has:uråldrig_nyckel", "room_has_item_state:trälåda_låst:stängd"], // Antag att lådan har ett state
+        "conditions": ["has:nyckel", "room_has_item_state:trälåda:stängd"], // Antag att lådan har ett state
         "response": "Den uråldriga nyckeln passar perfekt i låset! Du vrider om och öppnar lådan. Inuti hittar du en flaska fotogen.",
-        "pickup_item": "fotogen_flaska", // Tar automatiskt upp innehållet
-        "state_change": {"item":"trälåda_låst", "state":"öppen"},
-        "remove_from_room": "trälåda_låst" // Kanske lådan försvinner eller så blir den "trälåda_öppen"
+        "pickup_item": "fotogen", // Tar automatiskt upp innehållet
+        "state_change": {"item":"trälåda", "state":"öppen"},
+        "remove_from_room": "trälåda" // Kanske lådan försvinner eller så blir den "trälåda_öppen"
     }
   ],
   "gamla_observatoriet_ruin": [
     {
         "pattern": "(använd|placera) stjärnlins (i|på) (anordning|stjärnkarta|hållare)",
-        "conditions": ["has:komplett_stjärnlins", "at_location:gamla_observatoriet_ruin"],
+        "conditions": ["has:stjärnlins", "at_location:gamla_observatoriet_ruin"],
         "response": "Du placerar den kompletta stjärnlinsen i den rostiga hållaren på stjärnkartan. Linsen fokuserar det svaga stjärnljuset och projicerar en tidigare osynlig symbol på väggen bredvid kartan. En del av väggen glider undan och avslöjar en mörk passage!",
         "reveals_exit": {"direction":"studera_stjärnkartan", "destination":"stjärnkartans_rum_ingång"}, // Detta är lite fel, ska nog vara en direkt 'go' eller en flagga som gör att 'studera_stjärnkartan' leder rätt.
         "state_change": {"world_event":"observatorie_lins_aktiverad", "value":true}
@@ -171,9 +171,9 @@ const actions = {
   "giftträskets_kant": [
     {
         "pattern": "(använd|kasta) (renande kristall|kristall) (i|på) träsket",
-        "conditions": ["has:renande_kristall"],
+        "conditions": ["has:kristall"],
         "response": "Du kastar den renande kristallen i det giftiga vattnet. Där den landar börjar vattnet klarna och en smal, säker stig av fastare mark framträder genom träsket!",
-        "consume_item": "renande_kristall",
+        "consume_item": "kristall",
         "state_change": {"room":"giftträskets_kant", "feature":"stig_renad", "value":true},
         "reveals_exit": {"direction":"försök_korsa", "destination":"giftträsket_mitt"}
     }
@@ -181,9 +181,9 @@ const actions = {
   "den_sårade_väktarens_glänta": [
     {
         "pattern": "(hjälp|hela|ge|använd) (livets frö|frö|knopp|heligt vatten) (till|på) (väktare|träd)",
-        "conditions": ["has:livets_frö OR has:livets_lilla_knopp OR has:heligt_vatten_flaska", "at_location:den_sårade_väktarens_glänta", "not_has_flag:väktare_hjälpt"],
+        "conditions": ["has:livsfrö OR has:livsknopp OR has:källvatten", "at_location:den_sårade_väktarens_glänta", "not_has_flag:väktare_hjälpt"],
         "response": "Du närmar dig försiktigt det lidande trädet och [beroende på föremål: placerar fröet vid dess rötter / trycker knoppen mot barken / häller det heliga vattnet över såren]. Trädet skälver till och ett svagt, gyllene ljus sprider sig från kontaktpunkten. En del av mörkret tycks dra sig tillbaka. Väktaren verkar tacksam. En tidigare dold gång öppnar sig bakom trädet.",
-        "consume_item_if_present": ["livets_frö", "livets_lilla_knopp", "heligt_vatten_flaska"], // Förbruka det som användes
+        "consume_item_if_present": ["livsfrö", "livsknopp", "källvatten"], // Förbruka det som användes
         "set_flag": "väktare_hjälpt",
         "reveals_exit": {"direction":"hemlig_gång", "destination":"heliga_lundens_port"}
     }
@@ -191,9 +191,9 @@ const actions = {
   "stjärnkartans_rum_inre": [
     {
         "pattern": "(placera|använd|sätt) (runsten|samlad runsten) (på|i|vid) piedestal",
-        "conditions": ["has:samlad_runsten", "at_location:stjärnkartans_rum_inre"],
+        "conditions": ["has:runsten", "at_location:stjärnkartans_rum_inre"],
         "response": "Du placerar den samlade runstenen i en fördjupning på piedestalen. Stjärnprojektionen i taket börjar snurra snabbare och en skimrande portal materialiseras i rummets mitt!",
-        "consume_item": "samlad_runsten", // Kanske? Eller så behövs den senare.
+        "consume_item": "runsten", // Kanske? Eller så behövs den senare.
         "state_change": {"room":"stjärnkartans_rum_inre", "feature":"portal_aktiverad", "value":true},
         "reveals_exit": {"direction":"rör_piedestalen", "destination":"spegelportalens_kammare"} // Byt namn på exit eller gör det tydligare
     }
@@ -211,7 +211,7 @@ const actions = {
         "pattern": "(gå igenom|passera) porten",
         // Kan kräva en condition, t.ex. att man har hjälpt väktaren eller har ett "rent hjärta" (svårt att mäta)
         // eller att man har "livets_frö" som ett tecken på god avsikt.
-        "conditions": ["has:livets_frö"],
+        "conditions": ["has:livsfrö"],
         "response": "Du håller fram livets frö och portens blommor tycks nicka instämmande. Grenarna drar sig sakta åt sidan och du kan passera.",
         "go": "heliga_lunden"
     }
@@ -233,18 +233,18 @@ const actions = {
   "inre_helgedomen_förgård": [
     {
         "pattern": "(öppna|använd runsten på) dörr(en)?",
-        "conditions": ["has:samlad_runsten"], // Kanske runstenen inte förbrukades tidigare, eller så behövs en ny nyckel.
+        "conditions": ["has:runsten"], // Kanske runstenen inte förbrukades tidigare, eller så behövs en ny nyckel.
         "response": "Du håller fram den samlade runstenen mot den massiva dörren. Symbolen på stenen börjar pulsera i takt med ristningarna på dörren. Med ett dånande ljud glider stendörren upp!",
-        "consume_item": "samlad_runsten",
+        "consume_item": "runsten",
         "go": "skogens_hjärta_kammare"
     }
   ],
   "skogens_hjärta_kammare": [
     {
         "pattern": "(använd|placera|plantera) livets frö (vid|i|på) (hjärtat|skogens hjärta)",
-        "conditions": ["has:livets_frö", "at_location:skogens_hjärta_kammare"],
+        "conditions": ["has:livsfrö", "at_location:skogens_hjärta_kammare"],
         "response": "Du närmar dig det lidande Hjärtat och planterar försiktigt Livets Frö vid dess bas. Fröet börjar omedelbart spira och sända ut ett rent, helande ljus! Ljuset sprider sig genom Hjärtat, tränger undan mörkret och korruptionen. En våg av livsenergi sköljer genom kammaren och du känner hur skogen utanför drar en lättnadens suck. Hjärtat pulserar nu med ett starkt, friskt sken. Du har lyckats!",
-        "consume_item": "livets_frö",
+        "consume_item": "livsfrö",
         "state_change": {"world_event":"skogens_hjärta_renat", "value":true},
         "game_ending": {
             "title": "Skogens Beskyddare",

--- a/extract_mappings.js
+++ b/extract_mappings.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+
+const itemsJsContent = fs.readFileSync('items.js', 'utf-8');
+
+const mappings = {};
+const lines = itemsJsContent.split('\n');
+
+let currentItemName = null;
+
+for (const line of lines) {
+  const itemNameMatch = line.match(/"(.*?)": \{ \/\/ Tidigare (.*)/);
+  if (itemNameMatch) {
+    const newItemName = itemNameMatch[1];
+    const oldItemName = itemNameMatch[2].trim();
+    mappings[oldItemName] = newItemName;
+  } else {
+    // Simpler regex for cases where the comment is on its own line or part of the item block
+    const simpleCommentMatch = line.match(/\/\/\s*Tidigare\s+(.*)/);
+    if (simpleCommentMatch && currentItemName) {
+        const oldItemName = simpleCommentMatch[1].trim();
+        // Check if this old name isn't already mapped (to avoid overwriting if multiple comments exist)
+        // and that the currentItemName is not already a value (meaning this comment is for this item)
+        if (!mappings[oldItemName] && !Object.values(mappings).includes(currentItemName)) {
+            mappings[oldItemName] = currentItemName;
+        }
+    }
+
+    // Track the current item name based on the object key lines
+    const currentItemMatch = line.match(/^\s*"(.*?)"\s*:\s*\{/);
+    if (currentItemMatch) {
+        currentItemName = currentItemMatch[1];
+    }
+  }
+}
+
+console.log(JSON.stringify(mappings, null, 2));

--- a/places.js
+++ b/places.js
@@ -10,7 +10,7 @@ const places = {
    | |  | |
    |_|__|_|
     `,
-    "items": ["dagbok", "rostig_lykta"],
+    "items": ["dagbok", "lykta"],
     "exits": { "ut": "glömda_stigen" }
   },
   "glömda_stigen": {
@@ -29,7 +29,7 @@ const places = {
     дърво
    /____\\
     `,
-    "items": ["uråldrig_nyckel"],
+    "items": ["nyckel"],
     "exits": { "västerut": "glömda_stigen", "österut": "vattendragets_källa", "nedåt": "rotkällare" }
   },
   "vattendragets_källa": {
@@ -53,14 +53,14 @@ const places = {
   "murkna_grottan_första_rummet": {
     "desc": "Grottans första rum. Det är becksvart här inne.",
     "longDesc": "Du befinner dig i grottans första kammare. Mörkret är kompakt och det enda du hör är ljudet av droppande vatten. Utan en ljuskälla är det svårt att urskilja några detaljer.",
-    "conditions": ["not_has_item_state:rostig_lykta:Tänd"], // Exempel på hur man kan försvåra
-    "items": ["glimmande_mossa_klump"],
+    "conditions": ["not_has_item_state:lykta:Tänd"], // Exempel på hur man kan försvåra
+    "items": ["mossklump"],
     "exits": { "ut": "murkna_grottan_ingång", "djupare": "kristallgrottan" }
   },
   "kristallgrottan": {
     "desc": "En grotta vars väggar skimrar av otaliga kristaller.",
     "longDesc": "Ljuset från din lykta (eller den glimmande mossan) reflekteras i tusentals kristaller som täcker väggar och tak. Grottan gnistrar som en stjärnhimmel. Det är vackert, men gångarna är smala och förrädiska.",
-    "items": ["renande_kristall"],
+    "items": ["kristall"],
     "exits": { "tillbaka": "murkna_grottan_första_rummet", "ner": "underjordisk_sjö_strand" }
   },
   "underjordisk_sjö_strand": {
@@ -72,13 +72,13 @@ const places = {
    "glömda_altarets_ö": {
     "desc": "En liten ö mitt i den underjordiska sjön med ett förfallet altare.",
     "longDesc": "Mitt på den underjordiska sjön ligger en liten, dyster ö. Här står ett gammalt stenaltare, täckt av alger och fukt. Det verkar som om något saknas på altarets yta.",
-    "items": ["runsten_del1"],
+    "items": ["runstenbit"],
     "exits": { "tillbaka_över_sjön": "underjordisk_sjö_strand" }
   },
   "rotkällare": {
     "desc": "En trång och jordig rotkällare under den uråldriga eken.",
     "longDesc": "Du har klättrat ner i en trång och mörk rotkällare under den gamla ekens rötter. Det luktar starkt av jord och fukt. Rötterna slingrar sig längs väggarna som tjocka ormar. Det är svårt att röra sig här nere.",
-    "items": ["trälåda_låst"], // Behöver uråldrig_nyckel
+    "items": ["trälåda"], // Behöver uråldrig_nyckel
     "exits": { "upp": "uråldriga_eken", "gång": "viskande_gångarna_ingång" }
   },
   "viskande_gångarna_ingång": {
@@ -96,7 +96,7 @@ const places = {
   "svampdungen": {
     "desc": "En dunge fylld med självlysande svampar i olika färger.",
     "longDesc": "Grottan öppnar sig till en större sal där marken är täckt av stora, självlysande svampar. Deras mjuka sken i blått, grönt och violett lyser upp rummet och skapar ett drömskt landskap. Vissa svampar pulserar med ett eget ljus.",
-    "items": ["sömnsvamp", "stärkande_svamp"],
+    "items": ["sömnsvamp", "styrkesvamp"],
     "exits": { "söder": "viskande_gångarna_korsväg" }
   },
   "maskens_håla_mynning": {
@@ -119,7 +119,7 @@ const places = {
      ROOTS
     //   \\
     `,
-    "items": ["runsten_del2"],
+    "items": ["runstenbitett"],
     "exits": { "tillbaka": "maskens_håla_inre", "uppåt_via_rötter": "den_tysta_gläntan" }
   },
   "klippstigen": {
@@ -137,7 +137,7 @@ const places = {
   "örnens_näste_centrum": {
     "desc": "Mitten av det stora örnnästet.",
     "longDesc": "Du befinner dig i mitten av det stora, rufsiga örnnästet. Det luktar fågel och torra kvistar. Här, bland dun och små benrester, ligger en vacker fjäder och en liten, sliten läderpung.",
-    "items": ["örn_fjäder", "stjärnlins_bit1"],
+    "items": ["örnfjäder", "linsbit"],
     "exits": { "klättra_upp_ur_nästet": "örnens_näste_kant" }
   },
   "vindpinade_toppen": {
@@ -155,7 +155,7 @@ const places = {
   "gamla_observatoriet_ruin": {
     "desc": "Inne i det raserade observatoriet. Taket är borta.",
     "longDesc": "Du står inne i det som en gång var observatoriets huvudkupol. Taket har rasat in och stjärnorna lyser klart ovanför dig. En stor, rostig anordning i mitten ser ut att ha hållit en stor lins en gång i tiden. På väggen finns en urblekt stjärnkarta.",
-    "items": ["stjärnlins_bit2"], // Behöver kombineras
+    "items": ["linsbitett"], // Behöver kombineras
     "exits": { "nedför_trappan": "gamla_observatoriets_fot", "studera_stjärnkartan": "stjärnkartans_rum_ingång" } // Kräver komplett stjärnlins
   },
   "den_tysta_gläntan": {
@@ -167,13 +167,13 @@ const places = {
   "förvridna_trädens_stig": {
     "desc": "En stig kantad av förvridna, taggiga träd.",
     "longDesc": "Stigen leder dig djupare in i en del av skogen där träden är förvridna och taggiga. Grenarna sträcker sig som klor och luften är tung. Det känns som om skogen själv är sjuk här.",
-    "items": ["vissna_bär"], // Kanske giftiga
+    "items": ["bär"], // Kanske giftiga
     "exits": { "tillbaka_gläntan": "den_tysta_gläntan", "genom_snåren": "giftträskets_kant" } // Kräver kanske yxa
   },
   "giftträskets_kant": {
     "desc": "Kanten av ett träsk med bubblande, giftiggrönt vatten.",
     "longDesc": "Du står vid randen av ett stort träsk. Vattnet är tjockt, grönt och bubblar sakta. En stickande, kemisk lukt stiger upp och får dina ögon att tåras. Det ser inte ut att finnas någon säker väg över.",
-    "items": ["trasigt_andningsskydd"],
+    "items": ["andningsskydd"],
     "exits": { "tillbaka_stigen": "förvridna_trädens_stig", "försök_korsa": "giftträsket_mitt" } // Kräver skydd eller rening
   },
   "giftträsket_mitt": {
@@ -185,7 +185,7 @@ const places = {
   "den_sårade_väktarens_glänta": {
     "desc": "En glänta där ett enormt, uråldrigt träd sakta dör.",
     "longDesc": "Du når en glänta där ett gigantiskt, uråldrigt träd står. Det är tydligt att trädet lider – barken är sprucken, grenarna hänger slappt och en mörk sörja sipprar från dess stam. Det är Skogens Väktare, och den är döende.",
-    "items": ["livets_lilla_knopp"], // Om man lyckas hjälpa det lite
+    "items": ["livsknopp"], // Om man lyckas hjälpa det lite
     "exits": { "tillbaka_träsket": "giftträsket_mitt", "hemlig_gång": "heliga_lundens_port" } // Öppnas om väktaren hjälps
   },
   "stjärnkartans_rum_ingång": {
@@ -197,7 +197,7 @@ const places = {
   "stjärnkartans_rum_inre": {
     "desc": "Ett runt rum med en projektion av stjärnhimlen i taket.",
     "longDesc": "Du är i ett cirkulärt rum. I taket projiceras en komplex och rörlig stjärnhimmel. I mitten av rummet finns en piedestal med fördjupningar som liknar stjärnkonstellationer.",
-    "items": ["runsten_del3"],
+    "items": ["runstenbittva"],
     "exits": { "ut_igen": "stjärnkartans_rum_ingång", "rör_piedestalen": "spegelportalens_kammare" } // Kräver att man placerar runstenar?
   },
   "spegelportalens_kammare": {
@@ -215,7 +215,7 @@ const places = {
   "heliga_lunden": {
     "desc": "En fridfull, orörd lund där luften vibrerar av magi.",
     "longDesc": "Du kliver in i en lund av ojämförlig skönhet. Luften är ren och fylld av en söt doft. Solstrålar silar ner genom lövverket och skapar ett gyllene ljus. Gamla träd med silverglänsande bark står i en cirkel. I mitten finns en mossbelagd stig.",
-    "items": ["livets_frö"],
+    "items": ["livsfrö"],
     "exits": { "ut_porten": "heliga_lundens_port", "följ_stigen": "prövningens_stig" }
   },
   "prövningens_stig": {

--- a/synonyms.js
+++ b/synonyms.js
@@ -21,24 +21,24 @@ const synonyms = {
   drivved:        ['drivved', 'ved', 'träbitar', 'plankor'],
   rep:            ['rep', 'tamp', 'repet', 'näverrep', 'starkt rep'],
   flotte:         ['flotte', 'båt', 'farkost', 'träflotte'],
-  runstenbit:     ['runstenbit', 'stenbit', 'runbit', 'bit', 'runsten del 1', 'första runstenbiten'],
-  trälåda:        ['trälåda', 'låda', 'kista', 'låst låda', 'väderbiten låda'],
-  fotogen:        ['fotogen', 'fotogenflaska', 'bränsle', 'lampolja', 'flaska'],
+  runstenbit:     ['runstenbit', 'stenbit', 'runbit', 'bit', 'första runstenbiten', 'runsten del1'], // Updated
+  trälåda:        ['trälåda', 'låda', 'kista', 'låst låda', 'väderbiten låda', 'trälåda låst'], // Updated
+  fotogen:        ['fotogen', 'fotogenflaska', 'bränsle', 'lampolja', 'flaska', 'fotogen flaska'], // Updated
   sömnsvamp:      ['sömnsvamp', 'svamp', 'lilasvamp', 'sömnmedel'],
-  styrkesvamp:    ['styrkesvamp', 'svamp', 'rödsvamp', 'stärkandesvamp', 'kraftsvamp'],
-  runstenbitett:  ['runstenbitett', 'runstenbit', 'stenbit', 'bit', 'runsten del 2', 'andra runstenbiten', 'runstensbit ett'],
-  örnfjäder:      ['örnfjäder', 'fjäder', 'örnfjader', 'stor fjäder', 'vacker fjäder'],
-  linsbit:        ['linsbit', 'lins', 'glasbit', 'kristallglasbit', 'slipad linsbit', 'första linsbiten'],
-  linsbitett:     ['linsbitett', 'linsbit', 'lins', 'glasbit', 'andra linsbiten', 'linsbit ett'],
-  stjärnlins:     ['stjärnlins', 'lins', 'komplett lins', 'komplettstjärnlins', 'repad lins'],
-  bär:            ['bär', 'vissnabär', 'mörkabär', 'skrumpnabär', 'giftigabär'],
+  styrkesvamp:    ['styrkesvamp', 'svamp', 'rödsvamp', 'stärkandesvamp', 'kraftsvamp', 'stärkande svamp'], // Updated
+  runstenbitett:  ['runstenbitett', 'runstenbit', 'stenbit', 'bit', 'andra runstenbiten', 'runstensbit ett', 'runsten del2'], // Updated
+  örnfjäder:      ['örnfjäder', 'fjäder', 'örnfjader', 'stor fjäder', 'vacker fjäder', 'örn fjäder'], // Updated
+  linsbit:        ['linsbit', 'lins', 'glasbit', 'kristallglasbit', 'slipad linsbit', 'första linsbiten', 'stjärnlins bit1'], // Updated
+  linsbitett:     ['linsbitett', 'linsbit', 'lins', 'glasbit', 'andra linsbiten', 'linsbit ett', 'stjärnlins bit2'], // Updated
+  stjärnlins:     ['stjärnlins', 'lins', 'komplett lins', 'repad lins', 'komplett stjärnlins'], // Updated
+  bär:            ['bär', 'mörkabär', 'skrumpnabär', 'giftigabär', 'vissna bär'], // Updated
   yxa:            ['yxa', 'slitenyxa', 'vassyxa', 'träyxa'],
-  andningsskydd:  ['andningsskydd', 'skydd', 'mask', 'trasigtandningsskydd', 'gammalt skydd'],
-  livsknopp:      ['livsknopp', 'knopp', 'grönknopp', 'livets lilla knopp', 'växtknopp'],
-  runstenbittva:  ['runstenbittva', 'runstenbit', 'stenbit', 'bit', 'runsten del 3', 'tredje runstenbiten', 'runstensbit två'],
-  källvatten:     ['källvatten', 'vatten', 'heligtvatten', 'flaska med vatten', 'renande vatten'],
-  livsfrö:        ['livsfrö', 'frö', 'gyllenefrö', 'livetsfrö', 'magiskt frö'],
-  runsten:        ['runsten', 'samladrusten', 'komplettrunsten', 'lysandesten', 'symbolsten'],
+  andningsskydd:  ['andningsskydd', 'skydd', 'mask', 'gammalt skydd', 'trasigt andningsskydd'], // Updated
+  livsknopp:      ['livsknopp', 'knopp', 'grönknopp', 'växtknopp', 'livets lilla knopp'], // Updated
+  runstenbittva:  ['runstenbittva', 'runstenbit', 'stenbit', 'bit', 'tredje runstenbiten', 'runstensbit två', 'runsten del3'], // Updated
+  källvatten:     ['källvatten', 'vatten', 'heligtvatten', 'flaska med vatten', 'renande vatten', 'heligt vatten flaska'], // Updated
+  livsfrö:        ['livsfrö', 'frö', 'gyllenefrö', 'magiskt frö', 'livets frö'], // Updated
+  runsten:        ['runsten', 'komplettrunsten', 'lysandesten', 'symbolsten', 'samlad runsten'], // Updated
 
   // --- Custom Exit Directions ---
   "tillbaka": ["tillbaka", "gå tillbaka", "återvänd"],


### PR DESCRIPTION
I've updated item identifiers in actions.js, places.js, and synonyms.js to reflect the recent name changes. This includes names identified from comments (e.g., runsten_del1 -> runstenbit) and names corrected based on your feedback (e.g., rostig_lykta -> lykta, uråldrig_nyckel -> nyckel, glimmande_mossa_klump -> mossklump, renande_kristall -> kristall).

items.js already reflected the new names as primary keys. I reviewed engine.js and confirmed it does not use hardcoded old item names.